### PR TITLE
Removes more html if body tag exists uses only it's inner html which str...

### DIFF
--- a/scripts/firetext.js
+++ b/scripts/firetext.js
@@ -355,6 +355,10 @@ function cleanForPreview(text, documentType) {
               nodesToRemove = htmlNode.getElementsByTagName("hr");
           }
           htmlNode.innerHTML = completeHTML(htmlNode.innerHTML);
+          var bodyTag = htmlNode.getElementsByTagName("body");
+          if( bodyTag != undefined ) {
+            htmlNode.innerHTML = bodyTag[0].innerHTML;
+          }
           //the following will take a table of n rows and make it a table of 1 row
           var nodesToChange = htmlNode.getElementsByTagName("table");
           for(var t=0; t<nodesToChange.length; t++) {


### PR DESCRIPTION
...ips out doctype, html, head.
This should fix the example we saw.
