### PR TITLE
Don't go into fullscreen mode on settings close when fullscreen failed before

### DIFF
--- a/scripts/firetext.js
+++ b/scripts/firetext.js
@@ -1371,6 +1371,14 @@ document.addEventListener('fullscreenchange', onFullScreenChange);
 document.addEventListener('mozfullscreenchange', onFullScreenChange);
 document.addEventListener('webkitfullscreenchange', onFullScreenChange);
 
+function onFullScreenError() {
+	tempAutozen = false;
+}
+
+document.addEventListener('fullscreenerror', onFullScreenError);
+document.addEventListener('mozfullscreenerror', onFullScreenError);
+document.addEventListener('webkitfullscreenerror', onFullScreenError);
+
 firetext.alert = function(message) {
 	alert(message);
 };


### PR DESCRIPTION
I thought we would've fixed this in #224, but Chrome android has the same behavior.

It would be better to fix #232, but that's not simple.
