### PR TITLE
Focus filename when creating document

### DIFF
--- a/scripts/regions.js
+++ b/scripts/regions.js
@@ -98,6 +98,17 @@ function nav2() {
 		} else if (tempLoc == 'open') {
 			updateDocLists(['cloud']);		
 		}
+		
+		// Focus filename input
+		if (tempLoc == 'add') {
+			var onTransitionEnd = function () {
+				document.getElementById('createDialogFileName').focus();
+				tempElement.removeEventListener('transitionend', onTransitionEnd);
+				tempElement.removeEventListener('webkitTransitionEnd', onTransitionEnd);
+			};
+			tempElement.addEventListener('transitionend', onTransitionEnd);
+			tempElement.addEventListener('webkitTransitionEnd', onTransitionEnd);
+		}
 		/* End of customized section */
 	}
 }


### PR DESCRIPTION
It would be nicer to focus sooner, but 
1. immediately never works and e.g. after 100ms is unreliable for some reason
2. before the transition ends causes strange scrolling behavior in chrome desktop
