### PR TITLE
[desktop] Add first use buttons to main area

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,11 @@
 			<h1 class="firetext icon-">firetext</h1>
 		</header>
 		<div role="main" class="header-only" id="welcome-main-area">
+			<menu type="toolbar" class="desktop-only mainButtons">
+				<button data-click="nav" data-click-location="create"><span class="icon icon-create"></span><span class="buttonText" data-l10n-id="create"></span></button>
+				<button data-click="nav" data-click-location="import"><span class="icon icon-cloud-upload"></span><span class="buttonText" data-l10n-id="import"></span></button>
+				<button data-click="nav" data-click-location="settings" id="mainButtonConnectDropbox"><span class="icon icon-dropbox"></span><span class="buttonText" data-l10n-id="use-dropbox"></span></button>
+			</menu>
 			<article data-type="list" class="docsList" id="welcome-docs-list">
 				<div id="welcome-recents-area">
 					<h2 data-l10n-id="recent-documents"></h2>

--- a/scripts/cloud/cloud.js
+++ b/scripts/cloud/cloud.js
@@ -59,6 +59,9 @@ cloud.init = function () {
 				}								 
 			});
 		} 
+		
+		// Hide connect button
+		mainButtonConnectDropbox.style.display = 'none';
 	} else {
 		// Hide/Remove UI elements
 		welcomeDropboxArea.style.display = 'none';
@@ -87,6 +90,9 @@ cloud.init = function () {
 				firetext.recents.remove([dropRecents[i][0], dropRecents[i][1], dropRecents[i][2]], dropRecents[i][3], dropRecents[i][4]);
 			}
 		}	 
+		
+		// Show connect button
+		mainButtonConnectDropbox.style.display = '';
 	}
 	
 	updateAddDialog();

--- a/scripts/firetext.js
+++ b/scripts/firetext.js
@@ -21,7 +21,7 @@ firetext.initialized = new CustomEvent('firetext.initialized');
 firetext.isInitialized = false;
 var html = document.getElementsByTagName('html')[0], head = document.getElementsByTagName("head")[0];
 var themeColor = document.getElementById("theme-color");
-var loadSpinner, editor, toolbar, toolbarInterval, editWindow, editState, rawEditor, rawEditorElement, tempText, tabRaw, tabDesign, printButton;
+var loadSpinner, editor, toolbar, toolbarInterval, editWindow, editState, rawEditor, rawEditorElement, tempText, tabRaw, tabDesign, printButton, mainButtonConnectDropbox;
 var deviceType, fileChanged, saveTimeout, saving, urls={}, version = '0.5';
 var bold, boldCheckbox, italic, italicCheckbox, justifySelect, strikethrough, strikethroughCheckbox;
 var underline, underlineCheckbox;
@@ -150,6 +150,7 @@ function initElements() {
 	locationLegend = document.getElementById('locationLegend');
 	locationSelect = document.getElementById('createDialogFileLocation');	
 	printButton = document.getElementById('printButton');
+	mainButtonConnectDropbox = document.getElementById('mainButtonConnectDropbox');
 	
 	// Lists
 	welcomeDocsList = document.getElementById('welcome-docs-list');

--- a/style/main.css
+++ b/style/main.css
@@ -26,6 +26,26 @@ html, body {
   outline: none;
 }
 
+.mainButtons {
+  text-align: center;
+  padding: 0;
+}
+
+.mainButtons button {
+  width: auto;
+  font-size: 2rem;
+  background: #e7e7e7;
+  margin: .5rem;
+}
+
+.mainButtons button .icon {
+  margin-right: 1rem;
+}
+
+.mainButtons button b {
+  font-weight: normal !important;
+}
+
 .no-storage-notice {
   font-size: 2rem;
   text-align: center;


### PR DESCRIPTION
This adds some buttons to the main (welcome) area on the desktop to help a first-time user do something useful with the app as I talked about in https://github.com/codexa/firetext/issues/131#issuecomment-72144915.

Adds one l10n string.
