### PR TITLE
Welcome screen overhaul

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,10 +142,6 @@
 					<h2 data-l10n-id="recent-documents"></h2>
 					<ul id="welcome-recents-list"></ul>
 				</div>
-				<div id="welcome-edit-recents-area" style="display:none;">
-					<h2 data-l10n-id="recent-documents"></h2>
-					<ul id="welcome-edit-recents-list"></ul>
-				</div>
 			</article>
 		</div>
 	</section>

--- a/index.html
+++ b/index.html
@@ -141,13 +141,9 @@
 					<h2 data-l10n-id="recent-documents"></h2>
 					<ul id="welcome-recents-list"></ul>
 				</div>
-				<div id="welcome-device-area">
-					<h2 data-l10n-id="documents-device"></h2>
-					<ul id="welcome-device-list"></ul>
-				</div>
-				<div id="welcome-dropbox-area">
-					<h2 data-l10n-id="documents-dropbox"></h2>
-					<ul id="welcome-dropbox-list"></ul>
+				<div id="welcome-edit-recents-area" style="display:none;">
+					<h2 data-l10n-id="recent-documents"></h2>
+					<ul id="welcome-edit-recents-list"></ul>
 				</div>
 			</article>
 		</div>
@@ -264,15 +260,11 @@
 			<button data-click="navBack" data-l10n-title="close"><span class="icon icon-close"></span></button>
 			<h1 data-l10n-id="open"></h1>
 		</header>
-		<div role="main" class="header-only">
+		<div role="main" class="header-only" id="open-dialog-main-area">
 			<article data-type="list" class="docsList">
-				<div id="open-dialog-device-area">
-					<h2 data-l10n-id="documents-device"></h2>
-					<ul id="open-dialog-device-list"></ul>
-				</div>
-				<div id="open-dialog-dropbox-area">
-					<h2 data-l10n-id="documents-dropbox"></h2>
-					<ul id="open-dialog-dropbox-list"></ul>
+				<div id="open-dialog-recents-area">
+					<h2 data-l10n-id="recent-documents"></h2>
+					<ul id="open-dialog-recents-list"></ul>
 				</div>
 			</article>
 		</div>

--- a/index.html
+++ b/index.html
@@ -541,9 +541,12 @@
 					<ul>
 						<li class="noLink">
 							<aside class="pack-end">
-								<label class="pack-switch">
-									<input type="checkbox" id="previews-enabled-switch">
-									<span></span>
+								<label>
+									<select id="previews-select">
+										<option value="0" data-l10n-id="always-off"></option>
+										<option value="1" data-l10n-id="always-on"></option>
+										<option selected value="2" data-l10n-id="auto"></option>
+									</select>
 								</label>
 							</aside>
 							<p class="label" data-l10n-id="enable-file-previews"></p>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
 
 	<!-- Parsers -->
 	<script type="text/javascript" src="scripts/parsers/plain-text.js" defer></script>
+	<script type="text/javascript" src="scripts/parsers/odt.js/lib/odt.js" defer></script>
 
 	<!-- Building Blocks -->
 	<link rel="stylesheet" type="text/css" href="style/bb/buttons.css"/>

--- a/scripts/cloud/cloud.js
+++ b/scripts/cloud/cloud.js
@@ -19,6 +19,9 @@ cloud.init = function () {
 	if (firetext.settings.get('dropbox.enabled') == 'true') {
 		cloud.dropbox.init(function(error){
 			if (!error) {	
+				// Try again to fetch previews for dropfox files
+				resetPreviews('dropbox');
+				
 				// Code to get dropbox files
 				updateDocLists(['recents', 'cloud']);
 				
@@ -44,8 +47,6 @@ cloud.init = function () {
 		});
 	} else {
 		// Hide/Remove UI elements
-		welcomeDropboxArea.style.display = 'none';
-		openDialogDropboxArea.style.display = 'none';
 		if (locationDropbox) {
 			locationSelect.removeChild(locationDropbox);
 			locationDropbox = undefined;
@@ -74,13 +75,3 @@ cloud.init = function () {
 	
 	updateAddDialog();
 };
-
-cloud.updateDocLists = function (lists) {
-	if (firetext.settings.get('dropbox.enabled') == 'true' && cloud.dropbox.client) {
-		spinner();
-		cloud.dropbox.enumerate('/Documents/', function(DOCS) {
-			buildDocList(DOCS, [welcomeDropboxList, openDialogDropboxList], "dropbox-documents-found", 'dropbox');
-			spinner('hide');
-		});
-	}
-}

--- a/scripts/cloud/cloud.js
+++ b/scripts/cloud/cloud.js
@@ -20,7 +20,7 @@ cloud.init = function () {
 		cloud.dropbox.init(function(error){
 			if (!error) {	
 				// Code to get dropbox files
-				updateDocLists();
+				updateDocLists(['recents', 'cloud']);
 				
 				// Show UI elements
 				welcomeDropboxArea.style.display = 'block';

--- a/scripts/cloud/cloud_dropbox.js
+++ b/scripts/cloud/cloud_dropbox.js
@@ -12,7 +12,6 @@
 cloud.dropbox = {};
 
 // Dropbox
-var welcomeDropboxArea, welcomeDropboxList, openDialogDropboxArea, openDialogDropboxList;
 cloud.dropbox.client = undefined;
 
 
@@ -72,7 +71,7 @@ cloud.dropbox.signOut = function () {
 ------------------------*/
 cloud.dropbox.enumerate = function (directory, callback) {
 	if (directory && cloud.dropbox.client && cloud.dropbox.client.readdir) {
-		var docs = cloud.dropbox.client.readdir(directory, function(error, entries) {
+		var docs = cloud.dropbox.client.readdir(directory, function(error, entries, stat, entryStats) {
 			if (!error) {
 				for (var i = 0; i < entries.length; i++) {
 					var dir;
@@ -83,7 +82,9 @@ cloud.dropbox.enumerate = function (directory, callback) {
 					}
 					entries[i] = (dir + entries[i]);
 					entries[i] = firetext.io.split(entries[i]);
-					entries[i].push('');
+					entries[i].push(entryStats[i].mimeType);
+					entries[i].push('dropbox');
+					entries[i].push(entryStats[i].clientModifiedAt || entryStats[i].modifiedAt);
 					
 					// Only get documents
 					if (entries[i][2] != '.txt' && entries[i][2] != '.html' && entries[i][2] != '.htm' && entries[i][2] != '.odt') { // 0.4 && entries[i][2] != '.docx') {

--- a/scripts/cloud/cloud_dropbox.js
+++ b/scripts/cloud/cloud_dropbox.js
@@ -71,7 +71,7 @@ cloud.dropbox.signOut = function () {
 /* File IO
 ------------------------*/
 cloud.dropbox.enumerate = function (directory, callback) {
-	if (directory && cloud.dropbox.client && cloud.dropbox.client.readdir(directory)) {
+	if (directory && cloud.dropbox.client && cloud.dropbox.client.readdir) {
 		var docs = cloud.dropbox.client.readdir(directory, function(error, entries) {
 			if (!error) {
 				for (var i = 0; i < entries.length; i++) {
@@ -106,7 +106,7 @@ cloud.dropbox.enumerate = function (directory, callback) {
 				callback(entries);
 			} else {
 				cloud.dropbox.client.mkdir(directory, function() {
-					callback(cloud.dropbox.enumerate(directory, function(l) { return l; }));
+					cloud.dropbox.enumerate(directory, callback);
 				});
 			}
 		});

--- a/scripts/firetext.js
+++ b/scripts/firetext.js
@@ -284,7 +284,14 @@ function initListeners() {
 	welcomeDocsList.addEventListener(
 		'contextmenu', function contextmenu(event) {
 			event.preventDefault();
-			editDocs();
+			if (editState != true) {
+				editDocs();
+			}
+			var elm = event.target.closest('.fileListItem');
+			if (elm) {
+				elm.getElementsByClassName('edit-selected')[0].click();
+				updateSelectButton();
+			}
 		}
 	);
 }
@@ -1077,7 +1084,7 @@ function updateCheckbox(evt) {
 }
 
 function updateSelectButton() {
-	if (numSelected() == 0) {
+	if (numSelected() != numCheckboxes()) {
 		// Add select all button
 		document.getElementById("selectButtons").innerHTML = '<button data-click="selectAll" data-l10n-id="select-all"></button><button data-click="delete" class="danger" data-l10n-id="delete-selected"></button>';
 	}
@@ -1098,6 +1105,14 @@ function numSelected() {
 			}
 		}
 		return n;
+	}
+}
+
+function numCheckboxes() {
+	// Only use this function in edit mode
+	if (editState == true) {
+		var checkboxes = welcomeDocsList.getElementsByClassName('edit-selected');
+		return checkboxes.length;
 	}
 }
 

--- a/scripts/firetext.js
+++ b/scripts/firetext.js
@@ -441,16 +441,50 @@ function updateAllDocs() {
 		}
 		return true;
 	});
-	if(firetext.settings.get('previews.enabled') == 'false') {
+	buildDocList(allDocs, [welcomeRecentsList, openDialogRecentsList], 'documents-found');
+}
+
+function updatePreviewsEnabled() {
+	if(firetext.settings.get('previews.enabled') == 'never') {
 		Array.prototype.forEach.call(document.getElementsByClassName('docsList'), function(docList) {
 			docList.classList.remove('previews');
 		});
-	} else {
+		updatePreviews();
+	} else if(firetext.settings.get('previews.enabled') == 'always') {
 		Array.prototype.forEach.call(document.getElementsByClassName('docsList'), function(docList) {
 			docList.classList.add('previews');
 		});
+		updatePreviews();
+	} else {
+		var conn = navigator.connection || navigator.webkitConnection;
+		if(conn) {
+			conn.onchange = conn.ontypechange = updatePreviewsEnabledFromConnection;
+			updatePreviewsEnabledFromConnection();
+		} else {
+			Array.prototype.forEach.call(document.getElementsByClassName('docsList'), function(docList) {
+				docList.classList.add('previews');
+			});
+			updatePreviews();
+		}
 	}
-	buildDocList(allDocs, [welcomeRecentsList, openDialogRecentsList], 'documents-found');
+}
+
+function updatePreviewsEnabledFromConnection() {
+	if(firetext.settings.get('previews.enabled') == 'auto') {
+		var conn = navigator.connection || navigator.webkitConnection;
+		if(conn.type !== 'none') { // Don't change if no connection
+			if(['bluethooth', 'cellular', 'wimax'].indexOf(conn.type) !== -1) {
+				Array.prototype.forEach.call(document.getElementsByClassName('docsList'), function(docList) {
+					docList.classList.remove('previews');
+				});
+			} else {
+				Array.prototype.forEach.call(document.getElementsByClassName('docsList'), function(docList) {
+					docList.classList.add('previews');
+				});
+			}
+			updatePreviews();
+		}
+	}
 }
 
 function updateDocLists(lists) {
@@ -730,7 +764,7 @@ function getPreview(filetype, content, error) {
 }
 
 function updatePreviewNightModes(iframes) {
-	if(firetext.settings.get('previews.enabled') == 'false') {
+	if(!welcomeDocsList.classList.contains('previews')) {
 		return;
 	}
 	Array.prototype.forEach.call(iframes, function(iframe) {
@@ -783,7 +817,7 @@ function setPreview(description, previews) {
 }
 
 function updatePreviews() {
-	if(firetext.settings.get('previews.enabled') == 'false') {
+	if(!welcomeDocsList.classList.contains('previews')) {
 		return;
 	}
 	Array.prototype.forEach.call(document.getElementsByClassName('fileListItem'), function(item) {

--- a/scripts/io.js
+++ b/scripts/io.js
@@ -41,6 +41,8 @@ firetext.io.init = function (api, callback) {
 				return;
 			} else {
 				storage.onchange = function (change) {
+					var fileparts = firetext.io.split(change.path)
+					resetPreview(fileparts[0], fileparts[1], fileparts[2], 'internal');
 					updateDocLists(['internal', 'recents']);
 				}
 				enableInternalStorage();
@@ -158,6 +160,7 @@ firetext.io.enumerate = function (directory, callback) {
 				// Split name into parts
 				var thisFile = firetext.io.split(file.name);
 				thisFile[3] = file.type;
+				thisFile[5] = file.lastModifiedDate;
 				
 				// Don't get any files but docs
 				if (!thisFile[1] |
@@ -600,6 +603,9 @@ firetext.io.save = function (directory, filename, filetype, contentBlob, showBan
 								spinner('hide');
 							}
 							
+							// Refresh preview
+							resetPreview(directory, filename, filetype, 'internal');
+							
 							// Finish
 							saving = false;
 							callback();
@@ -631,6 +637,9 @@ firetext.io.save = function (directory, filename, filetype, contentBlob, showBan
 			if (showBanner) {
 				showSaveBanner(filePath);
 			}
+			
+			// Refresh preview
+			resetPreview(directory, filename, filetype, 'dropbox');
 			 
 			// Finish 
 			saving = false;

--- a/scripts/night.js
+++ b/scripts/night.js
@@ -71,4 +71,5 @@ function startNight(start) {
 			rawEditor.setOption("theme", 'default');
 		}
 	}
+	updatePreviewNightModes(document.querySelectorAll('[data-type="list"] li.fileListItem .fileItemDescription iframe'));
 }

--- a/scripts/regions.js
+++ b/scripts/regions.js
@@ -82,11 +82,7 @@ function nav2() {
 		}
 	
 		// Update docs lists
-		if (tempLoc == 'welcome') {
-			updateDocLists(['recents', 'cloud']);
-		} else if (tempLoc == 'open') {
-			updateDocLists(['cloud']);		
-		}
+		updateDocLists(['recents', 'cloud']);
 		
 		// Focus filename input
 		if (tempLoc == 'create' || tempLoc == 'save-as') {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -20,7 +20,7 @@ firetext.settings.init = function () {
 	var dropboxEnabled = document.querySelector('#dropbox-enabled-switch');
 	var languageSelect = document.querySelector('#language-select');
 	var nightmodeSelect = document.querySelector('#nightmode-select');
-	var previewsEnabled = document.querySelector('#previews-enabled-switch');
+	var previewsSelect = document.querySelector('#previews-select');
 	var statsEnabled = document.querySelector('#stats-enabled-switch');
 
 	// Autoload
@@ -109,19 +109,37 @@ firetext.settings.init = function () {
 	});
 
 	// Previews
-	if (firetext.settings.get('previews.enabled') != 'false') {
-		previewsEnabled.setAttribute('checked', '');
-		if (firetext.settings.get('previews.enabled') != 'true') {
-			firetext.settings.save('previews.enabled', 'true');
+	if (firetext.settings.get('previews.enabled') == 'always') {
+		previewsSelect.value = '1';
+	} else if (firetext.settings.get('previews.enabled') == 'never' || firetext.settings.get('previews.enabled') == 'false') {
+		previewsSelect.value = '0';
+		if (firetext.settings.get('previews.enabled') != 'never') {
+			firetext.settings.save('previews.enabled', 'never');
 		}
-	} else {	
-		previewsEnabled.removeAttribute('checked');
+	} else { // true, auto
+		previewsSelect.value = '2';
+		if (firetext.settings.get('previews.enabled') != 'auto') {
+			firetext.settings.save('previews.enabled', 'auto');
+		}
 	}
-	previewsEnabled.onchange = function () {
-		firetext.settings.save('previews.enabled', this.checked);
-		updateDocLists([]);
-		updatePreviews();
-	}
+	updatePreviewsEnabled();
+	previewsSelect.addEventListener('change', function () {
+		// Convert
+		var convertedPreviewsValue;
+		if (previewsSelect.value == '1') {
+			convertedPreviewsValue = 'always';
+		} else if (previewsSelect.value == '0') { 
+			convertedPreviewsValue = 'never';
+		} else {
+			convertedPreviewsValue = 'auto';
+		}	 
+
+		// Save
+		firetext.settings.save('previews.enabled', convertedPreviewsValue);
+
+		// Update
+		updatePreviewsEnabled();
+	});
 
 	// Stats
 	if (firetext.settings.get('stats.enabled') != 'false') {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -119,7 +119,8 @@ firetext.settings.init = function () {
 	}
 	previewsEnabled.onchange = function () {
 		firetext.settings.save('previews.enabled', this.checked);
-		updateDocLists(['recents']);
+		updateDocLists([]);
+		updatePreviews();
 	}
 
 	// Stats

--- a/style/desktop.css
+++ b/style/desktop.css
@@ -215,6 +215,37 @@ section[data-type="sidebar"] [role="toolbar"] button.active {
   margin-left: 0;
 }
 
+/* File Lists */
+@media (max-width: 1833px) {
+  [role="dialog"] .docsList.previews h2 {
+    padding: 0.5rem calc((100% - 800px) / 2 + 2rem);
+  }
+  
+  [role="dialog"] .docsList.previews ul {
+    padding: 1rem calc((100% - 800px) / 2);
+  }
+}
+
+@media (max-width: 1500px) {
+  [role="dialog"] .docsList.previews h2 {
+    padding: 0.5rem calc((100% - 600px) / 2 + 2rem);
+  }
+  
+  [role="dialog"] .docsList.previews ul {
+    padding: 1rem calc((100% - 600px) / 2);
+  }
+}
+
+@media (max-width: 1167px) {
+  [role="dialog"] .docsList.previews h2 {
+    padding: 0.5rem calc((100% - 400px) / 2 + 2rem);
+  }
+  
+  [role="dialog"] .docsList.previews ul {
+    padding: 1rem calc((100% - 400px) / 2);
+  }
+}
+
 /* Editor */
 #fileName {
   display: inline-block;

--- a/style/main.css
+++ b/style/main.css
@@ -17,9 +17,9 @@ html, body {
 }
 
 [role="main"] {
-    height: -moz-calc(100% - 5.2rem);
-    height: -webkit-calc(100% - 5.2rem);
-  height: calc(100% - 5.2rem);
+    height: -moz-calc(100% - 5rem);
+    height: -webkit-calc(100% - 5rem);
+  height: calc(100% - 5rem);
   overflow: auto;
   width: 100%;
   border: none;
@@ -216,9 +216,60 @@ label.pack-switch {
 
 
 /* File List */
+.docsList.previews {
+  background: #ddd;
+  min-height: calc(100% - 7rem);
+}
+
+[role="dialog"] .docsList.previews {
+  min-height: 100%;
+}
+
+.docsList.previews h2 {
+  padding: 0.5rem calc((100% - 1000px) / 2 + 2rem);
+}
+
+.docsList:not(.previews) ul {
+  display: flex;
+  flex-direction: column;
+}
+
+.docsList.previews ul {
+  padding: 1rem calc((100% - 1000px) / 2);
+  display: flex;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 1100px) {
+  .docsList.previews h2 {
+    padding: 0.5rem calc((100% - 800px) / 2 + 2rem);
+  }
+  
+  .docsList.previews ul {
+    padding: 1rem calc((100% - 800px) / 2);
+  }
+}
+
+@media (max-width: 900px) {
+  .docsList.previews h2 {
+    padding: 0.5rem calc((100% - 600px) / 2 + 2rem);
+  }
+  
+  .docsList.previews ul {
+    padding: 1rem calc((100% - 600px) / 2);
+  }
+}
+
 [data-type="list"] li.fileListItem {
-  background: #fff;
   cursor: pointer;
+}
+
+.docsList.previews li.fileListItem {
+  width: 200px;
+  display: inline-block;
+  vertical-align: top;
+  padding: 1rem;
+  border-bottom: none;
 }
 
 [data-type="list"] li.fileListItem:not(li.fileListItem + h2) {
@@ -238,13 +289,23 @@ label.pack-switch {
 
 [data-type="list"] li.fileListItem .fileItemDescription {
   display: none;
-  background: #ddd;
+  background: #fff;
   font-size: 1.2rem;
-  max-height: 5rem;
+  height: 200px;
   overflow: hidden;
-  padding-top: 1rem;
+  padding: 2.7rem;
   opacity: .8;
   pointer-events: none;
+  border-radius: 10px;
+  box-shadow: 0 0 5px #9E9E9E;
+}
+
+[data-type="list"] li.fileListItem .fileItemDescription iframe {
+  width: 670px;
+  height: 976px;
+  border: none;
+  transform: scale(.2);
+  transform-origin: top left;
 }
 
 .docsList.previews [data-type="list"] li.fileListItem .fileItemDescription {
@@ -254,6 +315,7 @@ label.pack-switch {
 [data-type="list"] li.fileListItem .fileItemInfo {
   padding: 0 2rem;
   overflow: hidden;
+  white-space: nowrap;
 }
 
 [data-type="list"] li.fileListItem .fileItemInfo aside.icon {
@@ -281,6 +343,10 @@ label.pack-switch {
 [data-type="list"] li.fileListItem .icon-arrow {
   font-size: 1.7rem;
   color: #aaa;
+}
+
+[data-type="list"] li.fileListItem:hover .icon-arrow {
+  color: #4a4a4a;
 }
 
 
@@ -486,6 +552,10 @@ aside select.dummy {
     -webkit-animation-name: rtlSpin;
     -o-animation-name: rtlSpin;
   animation-name: rtlSpin;
+}
+
+[dir="rtl"] [data-type="list"] li.fileListItem .fileItemDescription iframe {
+    transform-origin: top right;
 }
 
 [dir="rtl"] .icon-arrow {

--- a/style/main.css
+++ b/style/main.css
@@ -237,6 +237,7 @@ label.pack-switch {
 }
 
 [data-type="list"] li.fileListItem .fileItemDescription {
+  display: none;
   background: #ddd;
   font-size: 1.2rem;
   max-height: 5rem;
@@ -244,6 +245,10 @@ label.pack-switch {
   padding-top: 1rem;
   opacity: .8;
   pointer-events: none;
+}
+
+.docsList.previews [data-type="list"] li.fileListItem .fileItemDescription {
+  display: block;
 }
 
 [data-type="list"] li.fileListItem .fileItemInfo {

--- a/style/main.css
+++ b/style/main.css
@@ -349,6 +349,23 @@ label.pack-switch {
   color: #4a4a4a;
 }
 
+.docsList.editMode li.fileListItem .icon-arrow {
+  display: none;
+}
+
+.docsList:not(.editMode) li.fileListItem .edit-checkbox {
+  display: none;
+}
+
+.docsList:.editMode li.fileListItem .edit-checkbox {
+  display: block;
+}
+
+[data-type="list"] li.fileListItem label.pack-checkbox {
+  width: auto;
+  height: auto;
+}
+
 
 /* Buttons */
 .button-block {

--- a/style/mobile.css
+++ b/style/mobile.css
@@ -114,6 +114,48 @@ section[role="dialog"] + .background {
 	transform: translateX(80%) !important;
 }
 
+/* File Lists */
+.docsList.previews {
+	min-height: 100%;
+}
+
+.docsList.previews h2 {
+	padding: 0.5rem calc((100% - 450px) / 2 + 2rem);
+}
+
+.docsList.previews ul {
+	padding: 1rem calc((100% - 450px) / 2);
+}
+
+@media (max-width: 479px) {
+	.docsList.previews h2 {
+		padding: 0.5rem calc((100% - 300px) / 2 + 2rem);
+	}
+
+	.docsList.previews ul {
+		padding: 1rem calc((100% - 300px) / 2);
+	}
+}
+
+.docsList.previews li.fileListItem {
+	width: 150px;
+}
+
+.docsList.previews li.fileListItem .fileItemDescription {
+	padding: 1.5rem;
+	height: 150px;
+}
+
+.docsList.previews li.fileListItem .fileItemDescription iframe {
+	width: 300px;
+	height: 424px;
+	transform: scale(0.333);
+}
+
+.docsList.previews li.fileListItem .fileItemInfo {
+	padding: 0 1rem;
+}
+
 /* Tabs */
 .current [role="tabs"] [role="tab"],
 .parent [role="tabs"] [role="tab"],

--- a/style/night.css
+++ b/style/night.css
@@ -164,14 +164,23 @@
 }
 
 /* File lists */
+.night .docsList.previews {
+	background: #111;
+}
+
 .night [data-type="list"] li.fileListItem {
 	background: #111;
 	color: #a0a0a0;
 }
 
+.night .docsList.previews li.fileListItem {
+	background: none;
+}
+
 .night [data-type="list"] li.fileListItem .fileItemDescription {
-	background: #161616;
+	background: #000000;
 	color: #a0a0a0;
+	box-shadow: 0 0 5px #616161;
 }
 
 .night [data-type="list"] li.fileListItem .fileItemName {
@@ -180,6 +189,10 @@
 
 .night [data-type="list"] li.fileListItem .fileItemPath {
 	color: #a0a0a0;
+}
+
+.night [data-type="list"] li.fileListItem:hover .icon-arrow {
+  color: #fff;
 }
 
 /* Sidebar */


### PR DESCRIPTION
This PR consists of <del>four</del><ins>seven</ins> more or less independent commits (in the sense that you can apply the first n without the others if you want), but I thought I'd combine them since they share a theme.

It replaces the welcome screen with a single list of documents with rendered previews, as proposed in #300 and #319.

In the future, it would be nice to
- <del>Get the edit menu closer to the new document list</del>
- Add options to sort by most recently edited, by name, or even by frecency
- Add a button for the Show Previews setting on the welcome screen
