### PR TITLE
[desktop] Fix dialog header centering

### DIFF
--- a/style/desktop.css
+++ b/style/desktop.css
@@ -283,6 +283,10 @@ section[data-type="sidebar"] [role="toolbar"] button.active {
   padding: .46rem;
 }
 
+[role="dialog"]:not([data-type="edit"]) header:first-child h1 {
+  padding-right: 5rem;
+}
+
 /* Editor */
 #fileName {
   display: inline-block;


### PR DESCRIPTION
It's not perfectly centered on mobile either, but there at least there is a button on the right to push it left most of the times (removed on the desktop in #338).
